### PR TITLE
small update

### DIFF
--- a/apps/calibre-web.yml
+++ b/apps/calibre-web.yml
@@ -45,6 +45,7 @@
           - '/opt/appdata/{{pgrole}}:/books'
           - '/opt/appdata/{{pgrole}}/config:/calibre-web/config'
           - '/etc/localtime:/etc/localtime:ro'
+          - '/:/SERVER'
 
     - name: 'Setting {{pgrole}} ENV'
       set_fact:


### PR DESCRIPTION
added ability to get to /mnt
User should point to their Calibre database by using "/SERVER/mnt/unionfs/location_of_calibre_database
Profit