### PR TITLE
navidrome community app

### DIFF
--- a/apps/navidrome.yml
+++ b/apps/navidrome.yml
@@ -51,7 +51,7 @@
         pg_env:
           PUID: '1000'
           PGID: '1000'
-          ND_ENABLETRANSCODINGCONFIG: 'true'
+          ND_ENABLETRANSCODINGCONFIG: 'false'
 
     # MAIN DEPLOYMENT #############################################################
     - name: 'Deploying {{pgrole}}'

--- a/apps/navidrome.yml
+++ b/apps/navidrome.yml
@@ -51,6 +51,7 @@
         pg_env:
           PUID: '1000'
           PGID: '1000'
+          ND_ENABLETRANSCODINGCONFIG: 'true'
 
     # MAIN DEPLOYMENT #############################################################
     - name: 'Deploying {{pgrole}}'

--- a/apps/navidrome.yml
+++ b/apps/navidrome.yml
@@ -51,7 +51,7 @@
         pg_env:
           PUID: '1000'
           PGID: '1000'
-          ND_ENABLETRANSCODINGCONFIG: 'false'
+          ND_ENABLETRANSCODINGCONFIG: 'true'
 
     # MAIN DEPLOYMENT #############################################################
     - name: 'Deploying {{pgrole}}'

--- a/apps/navidrome.yml
+++ b/apps/navidrome.yml
@@ -60,7 +60,7 @@
         pull: yes
         volumes: '{{pg_volumes}}'
         env: '{{pg_env}}'
-        restart_policy: unless-stopped
+        restart_policy: always
         networks:
           - name: plexguide
             aliases:

--- a/apps/navidrome.yml
+++ b/apps/navidrome.yml
@@ -43,7 +43,7 @@
       set_fact:
         pg_volumes:
           - '/opt/appdata/{{pgrole}}:/data'
-          - '/mnt:/music:ro'
+          - '/mnt/gdrive/music:/music:ro'
           - '/etc/localtime:/etc/localtime:ro'
 
     - name: 'Setting Environment'

--- a/apps/navidrome.yml
+++ b/apps/navidrome.yml
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Title:      navidrome
+# Author(s):  mondychan
+# URL:        https://github.com/deluan/navidrome/ https://hub.docker.com/r/deluan/navidrome
+# GNU:        General Public License v3.0
+################################################################################
+---
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    # FACTS #######################################################################
+    - name: 'Set Known Facts'
+      set_fact:
+        pgrole: 'navidrome'
+        intport: '4533'
+        extport: '4533'
+        image: 'deluan/navidrome'
+
+    # CORE (MANDATORY) ############################################################
+    - name: 'Including cron job'
+      include_tasks: '/opt/communityapps/apps/_core.yml'
+
+    # LABELS ######################################################################
+    - name: 'Adding Traefik'
+      set_fact:
+        pg_labels:
+          traefik.enable: 'true'
+          traefik.port: '{{intport}}'
+          traefik.frontend.auth.forward.address: '{{gauth}}'
+          traefik.frontend.rule: 'Host:{{pgrole}}.{{domain.stdout}}{{tldset}}{{cname}}'
+          traefik.frontend.headers.SSLHost: '{{domain.stdout}}'
+          traefik.frontend.headers.SSLRedirect: 'true'
+          traefik.frontend.headers.STSIncludeSubdomains: 'true'
+          traefik.frontend.headers.STSPreload: 'true'
+          traefik.frontend.headers.STSSeconds: '315360000'
+          traefik.frontend.headers.browserXSSFilter: 'true'
+          traefik.frontend.headers.contentTypeNosniff: 'true'
+          traefik.frontend.headers.customResponseHeaders: 'X-Robots-Tag:noindex,nofollow,nosnippet,noarchive,notranslate,noimageindex'
+          traefik.frontend.headers.forceSTSHeader: 'true'
+
+    - name: 'Setting {{pgrole}} Volumes'
+      set_fact:
+        pg_volumes:
+          - '/opt/appdata/{{pgrole}}:/data'
+          - '/mnt:/music:ro'
+          - '/etc/localtime:/etc/localtime:ro'
+
+    - name: 'Setting Environment'
+      set_fact:
+        pg_env:
+          PUID: '1000'
+          PGID: '1000'
+
+    # MAIN DEPLOYMENT #############################################################
+    - name: 'Deploying {{pgrole}}'
+      docker_container:
+        name: '{{pgrole}}'
+        image: '{{image}}'
+        pull: yes
+        volumes: '{{pg_volumes}}'
+        env: '{{pg_env}}'
+        restart_policy: unless-stopped
+        networks:
+          - name: plexguide
+            aliases:
+              - '{{pgrole}}'
+        state: started
+        labels: '{{pg_labels}}'


### PR DESCRIPTION
im not sure about the "/mnt/gdrive/music:/music:ro" mapping , this is where i store the music myself, cant code the path into he install script

i have chosen the "ND_ENABLETRANSCODINGCONFIG: 'true'" flag to be enabled by default, tho the devs mark it as unsave
as per security doc https://www.navidrome.org/docs/usage/security/ , but i believe its fine since we hide behind oauth + you create admin pass on first login, feel free to disable it for community production

with both of those taken into consideration, the yml works fine for me :) 

